### PR TITLE
Clean up send_tweet to remove .unwrap()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 *go.sh
+*.iml
+.idea


### PR DESCRIPTION
Remove .unwrap() from send_tweet; Replacing it with an explicit Err type and ensuring it correctly bubbles out the call.

This will ensure that the program gracefully exits in a predictable fashion, rather than panicing if either HTTPS handler can't be created, or the tweet fails to send.